### PR TITLE
fix: make gcs benchmark docker image usable

### DIFF
--- a/e2e-examples/gcs/benchmark_docker/Dockerfile
+++ b/e2e-examples/gcs/benchmark_docker/Dockerfile
@@ -14,5 +14,6 @@ COPY ./ /work
 RUN cd /work && bazel build -c opt e2e-examples/gcs/benchmark:benchmark
 
 FROM debian:stable-slim
+RUN apt update && apt -y install ca-certificates
 COPY --from=0 /work/bazel-bin/e2e-examples/gcs/benchmark/benchmark /
 CMD ["./benchmark"]


### PR DESCRIPTION
Without the CA certificates the image is not usable, as
the benchmark cannot find the root certificates.