### PR TITLE
fix: configure REST uploads with large buffers too

### DIFF
--- a/e2e-examples/gcs/benchmark/gcscpp_runner.cc
+++ b/e2e-examples/gcs/benchmark/gcscpp_runner.cc
@@ -35,9 +35,8 @@ static google::cloud::storage::Client CreateClient(
     return ::google::cloud::storage_experimental::DefaultGrpcClient(
         opts.set<google::cloud::storage_experimental::GrpcPluginOption>("media")
             .set<google::cloud::EndpointOption>(target));
-  } else {
-    return ::google::cloud::storage::Client();
   }
+  return ::google::cloud::storage::Client(std::move(opts));
 }
 
 bool GcscppRunner::Run() {


### PR DESCRIPTION
For resumable uploads, the analogous to a `WriteObject()` call is a `PUT`
request uploading the next chunk in the object.  To make comparisons
fair, we want to make the same number of `PUT` requests as we make
`WriteObject()` requests.  That requires configuring the REST client
with the same options.