### PR TITLE
Add optional OpenTelemetry metric exports

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,6 +51,17 @@ switched_rules_by_language(
     grpc = True,
 )
 
+
+# Load OpenTelemetry dependencies after load.
+load("@io_opentelemetry_cpp//bazel:repository.bzl", "opentelemetry_cpp_deps")
+
+opentelemetry_cpp_deps()
+
+# (required after v1.8.0) Load extra dependencies required for OpenTelemetry
+load("@io_opentelemetry_cpp//bazel:extra_deps.bzl", "opentelemetry_extra_deps")
+
+opentelemetry_extra_deps()
+
 load('@com_github_grpc_grpc//bazel:grpc_deps.bzl', 'grpc_deps')
 
 grpc_deps()

--- a/e2e-examples/gcs/benchmark/BUILD
+++ b/e2e-examples/gcs/benchmark/BUILD
@@ -14,44 +14,44 @@
 
 cc_library(
     name = "channel_creator",
-    hdrs = [
-        "channel_creator.h",
-    ],
     srcs = [
         "channel_creator.cc",
     ],
+    hdrs = [
+        "channel_creator.h",
+    ],
     deps = [
-        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
     ],
 )
 
 cc_library(
     name = "channel_policy",
-    hdrs = [
-        "channel_policy.h",
-    ],
     srcs = [
         "channel_policy.cc",
     ],
+    hdrs = [
+        "channel_policy.h",
+    ],
     deps = [
-        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
+        "channel_poller",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
-        "channel_poller",
+        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
     ],
 )
 
 cc_library(
     name = "channel_poller",
-    hdrs = [
-        "channel_poller.h",
-    ],
     srcs = [
         "channel_poller.cc",
+    ],
+    hdrs = [
+        "channel_poller.h",
     ],
     deps = [
         "@com_github_grpc_grpc//:grpc++",
@@ -61,11 +61,11 @@ cc_library(
 
 cc_library(
     name = "gcscpp_runner",
-    hdrs = [
-        "gcscpp_runner.h",
-    ],
     srcs = [
         "gcscpp_runner.cc",
+    ],
+    hdrs = [
+        "gcscpp_runner.h",
     ],
     deps = [
         "object_resolver",
@@ -75,34 +75,34 @@ cc_library(
         "runner_watcher",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
-        "@google_cloud_cpp//:storage",
         "@google_cloud_cpp//:experimental-storage_grpc",
+        "@google_cloud_cpp//:storage",
     ],
 )
 
 cc_library(
     name = "grpc_admin",
-    hdrs = [
-        "grpc_admin.h",
-    ],
     srcs = [
         "grpc_admin.cc",
     ],
+    hdrs = [
+        "grpc_admin.h",
+    ],
     deps = [
-        "@com_google_absl//absl/strings",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpcpp_admin",
+        "@com_google_absl//absl/strings",
     ],
 )
 
 cc_library(
     name = "grpc_runner",
-    hdrs = [
-        "grpc_runner.h",
-    ],
     srcs = [
         "grpc_runner.cc",
         "grpc_xtra.cc",
+    ],
+    hdrs = [
+        "grpc_runner.h",
     ],
     deps = [
         "channel_creator",
@@ -113,22 +113,22 @@ cc_library(
         "runner",
         "runner_watcher",
         "work_queue",
-        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//src/proto/grpc/health/v1:health_proto",
         "@com_google_absl//absl/crc:crc32c",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
     ],
 )
 
 cc_library(
     name = "object_resolver",
-    hdrs = [
-        "object_resolver.h",
-    ],
     srcs = [
         "object_resolver.cc",
+    ],
+    hdrs = [
+        "object_resolver.h",
     ],
     deps = [
         "@com_google_absl//absl/strings",
@@ -137,11 +137,11 @@ cc_library(
 
 cc_library(
     name = "work_queue",
-    hdrs = [
-        "work_queue.h",
-    ],
     srcs = [
         "work_queue.cc",
+    ],
+    hdrs = [
+        "work_queue.h",
     ],
     deps = [
         "@com_google_absl//absl/synchronization",
@@ -150,67 +150,67 @@ cc_library(
 
 cc_library(
     name = "parameters",
-    hdrs = [
-        "parameters.h",
-    ],
     srcs = [
         "parameters.cc",
+    ],
+    hdrs = [
+        "parameters.h",
     ],
     deps = [
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/strings:str_format",
-    ],    
+    ],
 )
 
 cc_library(
     name = "random_data",
-    hdrs = [
-        "random_data.h",
-    ],
     srcs = [
         "random_data.cc",
     ],
+    hdrs = [
+        "random_data.h",
+    ],
     deps = [
-        "@com_google_absl//absl/strings:cord",
         "@com_google_absl//absl/random",
+        "@com_google_absl//absl/strings:cord",
     ],
 )
 
 cc_library(
     name = "runner_watcher",
-    hdrs = [
-        "runner_watcher.h",
-    ],
     srcs = [
         "runner_watcher.cc",
     ],
+    hdrs = [
+        "runner_watcher.h",
+    ],
     deps = [
         "parameters",
-        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
     ],
 )
 
 cc_library(
     name = "runner",
-    hdrs = [
-        "runner.h",
-    ],
     srcs = [
         "runner.cc",
     ],
+    hdrs = [
+        "runner.h",
+    ],
     deps = [
-        "parameters",
         "channel_policy",
         "object_resolver",
+        "parameters",
         "runner_watcher",
-        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
     ],
 )
 
@@ -224,17 +224,19 @@ cc_binary(
     deps = [
         "channel_creator",
         "channel_policy",
-        "parameters",
-        "runner",
-        "runner_watcher",
         "gcscpp_runner",
         "grpc_admin",
         "grpc_runner",
-        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
+        "parameters",
+        "runner",
+        "runner_watcher",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//test/core/test_util:stack_tracer",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
+        "@io_opentelemetry_cpp//exporters/prometheus:prometheus_exporter",
+        "@io_opentelemetry_cpp//sdk/src/metrics",
     ],
 )

--- a/e2e-examples/gcs/benchmark/main.cc
+++ b/e2e-examples/gcs/benchmark/main.cc
@@ -19,6 +19,17 @@
 #include "absl/flags/parse.h"
 #include "absl/strings/str_format.h"
 #include "absl/time/time.h"
+
+#include "opentelemetry/exporters/prometheus/exporter_factory.h"
+#include "opentelemetry/exporters/prometheus/exporter_options.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
+#include "opentelemetry/sdk/metrics/view/instrument_selector_factory.h"
+#include "opentelemetry/sdk/metrics/view/meter_selector_factory.h"
+#include "opentelemetry/sdk/metrics/view/view_factory.h"
+
+#include <grpcpp/ext/otel_plugin.h>
+#include <grpcpp/grpcpp.h>
+
 #include "channel_creator.h"
 #include "channel_policy.h"
 #include "gcscpp_runner.h"
@@ -27,11 +38,35 @@
 #include "parameters.h"
 #include "print_result.h"
 #include "runner.h"
+
 #include "test/core/test_util/stack_tracer.h"
+
+using ::opentelemetry::sdk::metrics::InstrumentSelectorFactory;
+using ::opentelemetry::sdk::metrics::InstrumentType;
+using ::opentelemetry::sdk::metrics::MeterSelectorFactory;
+using ::opentelemetry::sdk::metrics::ViewFactory;
+
+void AddLatencyView(opentelemetry::sdk::metrics::MeterProvider *provider,
+                    const std::string &name, const std::string &unit) {
+  auto histogram_config = std::make_shared<
+      opentelemetry::sdk::metrics::HistogramAggregationConfig>();
+  histogram_config->boundaries_ = {
+      0,     0.00001, 0.00005, 0.0001, 0.0003, 0.0006, 0.0008, 0.001, 0.002,
+      0.003, 0.004,   0.005,   0.006,  0.008,  0.01,   0.013,  0.016, 0.02,
+      0.025, 0.03,    0.04,    0.05,   0.065,  0.08,   0.1,    0.13,  0.16,
+      0.2,   0.25,    0.3,     0.4,    0.5,    0.65,   0.8,    1,     2,
+      5,     10,      20,      50,     100};
+  provider->AddView(
+      InstrumentSelectorFactory::Create(InstrumentType::kHistogram, name, unit),
+      MeterSelectorFactory::Create("grpc-c++", grpc::Version(), ""),
+      ViewFactory::Create(
+          name, "", unit,
+          opentelemetry::sdk::metrics::AggregationType::kHistogram,
+          std::move(histogram_config)));
+}
 
 int main(int argc, char **argv) {
   grpc_core::testing::InitializeStackTracer(argv[0]);
-
   absl::ParseCommandLine(argc, argv);
   absl::optional<Parameters> parameters = GetParameters();
   if (!parameters.has_value()) {
@@ -39,7 +74,7 @@ int main(int argc, char **argv) {
   }
 
   if (parameters->grpc_admin > 0) {
-    StartGrpcAdmin(parameters->grpc_admin );
+    StartGrpcAdmin(parameters->grpc_admin);
   }
 
   // Create a runner based on a client
@@ -54,6 +89,35 @@ int main(int argc, char **argv) {
   } else {
     std::cerr << "Invalid client: " << parameters->client << std::endl;
     return 1;
+  }
+
+  if (parameters->prometheus_port != 0) {
+    opentelemetry::exporter::metrics::PrometheusExporterOptions opts;
+    opts.url = absl::StrCat("0.0.0.0:", parameters->prometheus_port);
+    auto prometheus_exporter =
+        opentelemetry::exporter::metrics::PrometheusExporterFactory::Create(
+            opts);
+    auto meter_provider =
+        std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
+    // The default histogram boundaries are not granular enough for RPCs.
+    // Override the "grpc.client.attempt.duration" view as recommended by
+    // https://github.com/grpc/proposal/blob/master/A66-otel-stats.md.
+    AddLatencyView(meter_provider.get(), "grpc.client.attempt.duration", "s");
+    AddLatencyView(meter_provider.get(),
+                   "grpc.client.attempt.rcvd_total_compressed_message_size",
+                   "B");
+    AddLatencyView(meter_provider.get(),
+                   "grpc.client.attempt.sent_total_compressed_message_size",
+                   "B");
+    meter_provider->AddMetricReader(std::move(prometheus_exporter));
+    auto status = grpc::OpenTelemetryPluginBuilder()
+                      .SetMeterProvider(std::move(meter_provider))
+                      .BuildAndRegisterGlobal();
+    if (!status.ok()) {
+      std::cerr << "Failed to register gRPC OpenTelemetry Plugin: "
+                << status.ToString() << std::endl;
+      return static_cast<int>(status.code());
+    }
   }
 
   // Let's run!

--- a/e2e-examples/gcs/benchmark/parameters.cc
+++ b/e2e-examples/gcs/benchmark/parameters.cc
@@ -76,17 +76,19 @@ ABSL_FLAG(
     "Parameter for cpolicy (e.g. pool uses this as the number of channels)");
 ABSL_FLAG(int, ctest, 0, "Test to get a list of peers from grpclb");
 ABSL_FLAG(int, mtest, 0, "Test to get metadata");
+ABSL_FLAG(int, prometheus_port, 0,
+          "Port used to serve prometheus metrics");
 
 const char *ToOperationTypeString(OperationType operationType) {
   switch (operationType) {
-    case OperationType::Read:
-      return "Read";
-    case OperationType::RandomRead:
-      return "Random-Read";
-    case OperationType::Write:
-      return "Write";
-    default:
-      return "None";
+  case OperationType::Read:
+    return "Read";
+  case OperationType::RandomRead:
+    return "Random-Read";
+  case OperationType::Write:
+    return "Write";
+  default:
+    return "None";
   }
 }
 
@@ -147,5 +149,6 @@ absl::optional<Parameters> GetParameters() {
   p.carg = absl::GetFlag(FLAGS_carg);
   p.ctest = absl::GetFlag(FLAGS_ctest);
   p.mtest = absl::GetFlag(FLAGS_mtest);
+  p.prometheus_port = absl::GetFlag(FLAGS_prometheus_port);
   return p;
 }

--- a/e2e-examples/gcs/benchmark/parameters.h
+++ b/e2e-examples/gcs/benchmark/parameters.h
@@ -65,6 +65,8 @@ struct Parameters {
   int carg;
   int ctest;
   int mtest;
+
+  int prometheus_port;
 };
 
 absl::optional<Parameters> GetParameters();


### PR DESCRIPTION
Use `./benchmark --prometheus_port=9456` to export OpenTelemetry metrics `<host>:9456/metrics`

I also ran buildifier, and a bit of clang-format on main.cc